### PR TITLE
fix symlink detecting on windows

### DIFF
--- a/Launcher/source/hasher/HashedDir.java
+++ b/Launcher/source/hasher/HashedDir.java
@@ -2,6 +2,8 @@ package launcher.hasher;
 
 import launcher.LauncherAPI;
 import launcher.helper.IOHelper;
+import launcher.helper.JVMHelper;
+import launcher.helper.JVMHelper.OS;
 import launcher.helper.VerifyHelper;
 import launcher.serialize.HInput;
 import launcher.serialize.HOutput;
@@ -260,7 +262,7 @@ public final class HashedDir extends HashedEntry
 
             // Verify is not symlink
             // Symlinks was disallowed because modification of it's destination are ignored by DirWatcher
-            if (!allowSymlinks && attrs.isSymbolicLink())
+            if (!allowSymlinks && (JVMHelper.OS_TYPE == OS.MUSTDIE && !dir.toRealPath().equals(dir) || JVMHelper.OS_TYPE != OS.MUSTDIE && attrs.isSymbolicLink()))
             {
                 throw new SecurityException("Symlinks are not allowed");
             }
@@ -278,7 +280,7 @@ public final class HashedDir extends HashedEntry
         public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException
         {
             // Verify is not symlink
-            if (!allowSymlinks && attrs.isSymbolicLink())
+            if (!allowSymlinks && (JVMHelper.OS_TYPE == OS.MUSTDIE && !file.toRealPath().equals(file) || JVMHelper.OS_TYPE != OS.MUSTDIE && attrs.isSymbolicLink()))
             {
                 throw new SecurityException("Symlinks are not allowed");
             }


### PR DESCRIPTION
после получасовых увлекательных тестов было выявлено, что java.nio.file.attribute.BasicFileAttributes.isSymbolicLink() на винде нихера не работает

в Files.isSymbolicLink() так и написано 

> _Returns:
> true if the file is a symbolic link; false if the file does not exist, is not a symbolic link, or it cannot be determined if the file is a symbolic link or not._